### PR TITLE
docs: Add disclaimer about old package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Simple library to fetch all favicons from a webpage.
 
 ## Installation
 
-You can install favify with any NodeJS package managers. Below is the example of installing favify with `npm`
+You can install `favify` with any NodeJS package managers. Below is the example of installing `favify` with `npm`
 
 ```bash
 npm install @namchee/favify
 ```
 
+> Note: [favify](https://www.npmjs.com/package/favify) is an old-and-unmaintained version of the library. For the latest version, always use `@namchee/favify`
 ## API
 
 ### fetchFavicons


### PR DESCRIPTION
## Overview

This pull request triggers a re-release of the package under a new name `@namchee/favify`, which is actually the intended package name from start.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.2--canary.1.44cd2ba1da8efdd4f34d8e21cd76a78322cf8785.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/favify@0.1.2--canary.1.44cd2ba1da8efdd4f34d8e21cd76a78322cf8785.0
  # or 
  yarn add @namchee/favify@0.1.2--canary.1.44cd2ba1da8efdd4f34d8e21cd76a78322cf8785.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
