### PR TITLE
fix(ci): Add npmignore to exclude the dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.editorconfig
+.eslintrc.cjs
+jest.config.cjs
+prettier.config.js
+.github


### PR DESCRIPTION
## Overview

This pull request adds `.npmignore` to exclude `dist` from the ignore, which previously breaks the release.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.4--canary.3.da56b7132ddaffcd0aab53e85b3c03653d4d19f8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/favify@0.1.4--canary.3.da56b7132ddaffcd0aab53e85b3c03653d4d19f8.0
  # or 
  yarn add @namchee/favify@0.1.4--canary.3.da56b7132ddaffcd0aab53e85b3c03653d4d19f8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
