### PR TITLE
fix: Enforce extension on imports so it does not break

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 jest.config.cjs
 prettier.config.js
 .github
+.autorc

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import fetch from 'node-fetch';
 import { load } from 'cheerio';
 
-import { getFilenameFromPath, getMIMEType } from './utils';
-import type { Favicon, FetcherConfig, Manifest } from './types';
+import { getFilenameFromPath, getMIMEType } from './utils.js';
+import type { Favicon, FetcherConfig, Manifest } from './types.js';
 
 /**
  * Fetch all functional favicons from a webpage.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "eslint-config-namchee/tsconfig",
   "compilerOptions": {
+    "module": "ES2020",
     "outDir": "./dist",
     "importHelpers": true,
     "declaration": true


### PR DESCRIPTION
## Overview

This pull request adds extensions to all imports since ~~the module resolution sucks for pure ESM modules~~ ESM cannot recognize no-extension imports.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.5--canary.4.646c95bf2239b75b07f9027b1415d8fc4fceecf1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/favify@0.1.5--canary.4.646c95bf2239b75b07f9027b1415d8fc4fceecf1.0
  # or 
  yarn add @namchee/favify@0.1.5--canary.4.646c95bf2239b75b07f9027b1415d8fc4fceecf1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
